### PR TITLE
Fixed wrong exported format

### DIFF
--- a/app/Http/Controllers/BibliographyController.php
+++ b/app/Http/Controllers/BibliographyController.php
@@ -51,7 +51,7 @@ class BibliographyController extends Controller
                     case 'user_id':
                         break;
                     default:
-                        $content .= '    '.$k.'= {'.$a.'}';
+                        $content .= '    '.$k.' = {'.$a.'}';
                         $content .= "\n";
                         break;
                 }

--- a/app/Http/Controllers/BibliographyController.php
+++ b/app/Http/Controllers/BibliographyController.php
@@ -51,7 +51,7 @@ class BibliographyController extends Controller
                     case 'user_id':
                         break;
                     default:
-                        $content .= '    '.$k.': {'.$a.'}';
+                        $content .= '    '.$k.'= {'.$a.'}';
                         $content .= "\n";
                         break;
                 }


### PR DESCRIPTION
Bibtex was created with the format of:
attr: {value}

but is specified as:
attr = {value}

This was fixed now.