### PR TITLE
[0.10] fix misc

### DIFF
--- a/app/AttributeTypes/IconclassAttribute.php
+++ b/app/AttributeTypes/IconclassAttribute.php
@@ -6,7 +6,7 @@ class IconclassAttribute extends AttributeBase
 {
     protected static string $type = "iconclass";
     protected static bool $inTable = true;
-    protected static ?string $field = 'int_val';
+    protected static ?string $field = 'str_val';
 
     public static function fromImport(int|float|bool|string $data) : mixed {
         return $data;

--- a/resources/js/components/EntityDetail.vue
+++ b/resources/js/components/EntityDetail.vue
@@ -877,7 +877,7 @@
 
                     toast.$toast(
                         t('main.entity.toasts.updated.msg', {
-                            name: data.name
+                            name: data.entity.name
                         }),
                         t('main.entity.toasts.updated.title'),
                         {

--- a/resources/js/i18n/de.json
+++ b/resources/js/i18n/de.json
@@ -320,7 +320,7 @@
             "toasts": {
                 "updated": {
                     "title": "Entität aktualisiert",
-                    "msg": "Daten von {name} wurden erfolgreich aktualisiert."
+                    "msg": "Daten von „{name}“ wurden erfolgreich aktualisiert."
                 },
                 "deleted": {
                     "title": "Entität gelöscht",

--- a/resources/js/i18n/en.json
+++ b/resources/js/i18n/en.json
@@ -320,7 +320,7 @@
             "toasts": {
                 "updated": {
                     "title": "Entity updated",
-                    "msg": "Data of {name} successfully updated."
+                    "msg": "Data of ‚{name}‘ successfully updated."
                 },
                 "deleted": {
                     "title": "Entity deleted",


### PR DESCRIPTION
1. After reworking how entity data is stored, the structure of returned data has changed. I forgot to update the location of the entity name in the success toast
2. Iconclass attribute had the wrong column in `$field`