### PR TITLE
[0.10] Added processors to transform type value and all tags to lower-case

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,7 @@ All notable changes to this project will be documented in this file.
 - Data Importer: Now supports the Boolean attribute with the value 'x'
 - Append `et al.` to citations in reference tab and modal
 - Do not show "!" for attributes without value & replace initial "!" with "?" for attributes with value, but no certainty set
+- Bibtex import now is case-insensitive for type and keys
 
 ## 0.9.14
 ### Added

--- a/app/Http/Controllers/BibliographyController.php
+++ b/app/Http/Controllers/BibliographyController.php
@@ -8,6 +8,7 @@ use Illuminate\Support\Facades\DB;
 use RenanBr\BibTexParser\Listener;
 use RenanBr\BibTexParser\Exception\ParserException;
 use RenanBr\BibTexParser\Parser;
+use RenanBr\BibTexParser\Processor\TagNameCaseProcessor;
 
 class BibliographyController extends Controller
 {
@@ -93,6 +94,12 @@ class BibliographyController extends Controller
         $file = $request->file('file');
         $noOverwriteOnDup = $request->input('no-overwrite', false);
         $listener = new Listener();
+        $listener->addProcessor(new TagNameCaseProcessor(CASE_LOWER));
+        $listener->addProcessor(function($entry) {
+            $entry['_type'] = strtolower($entry['_type']);
+            $entry['type'] = strtolower($entry['type']);
+            return $entry;
+        });
         $parser = new Parser();
         $parser->addListener($listener);
         try {


### PR DESCRIPTION
I noticed by accident, that the importer fails when trying to load a file that is not all lower case (for type and keys).
Bibtex is like always totallly chill with everything that you throw at it (thanks for nothing 🙄).

So I added two processors to the convenient BibTex parser to:

1. Transform all tag keys to lower case: AUTHOR -> author
2. Transform all type values to lower case: @Article or @ARTICLE -> 'type': 'article'