### PR TITLE
0.10 fix bibtex files non selectable on win mac

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,7 @@ All notable changes to this project will be documented in this file.
 - Bibtex type `inbook` could not be added
 - Activity was not shown/blank
 - Adding empty table was possible and error was thrown
+- Bibliography import: files with .bib & .bibtex not visible on Windows and Mac
 ### Changed
 - _Entity tree_ sorting is now accessible through ...-menu
 - Reset Password Workflow

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,7 @@ All notable changes to this project will be documented in this file.
 - Data Importer: Now supports the Boolean attribute with the value 'x'
 - Append `et al.` to citations in reference tab and modal
 - Do not show "!" for attributes without value & replace initial "!" with "?" for attributes with value, but no certainty set
+- Bibtex import now is case-insensitive for type and keys
 
 ## 0.9.14
 ### Added

--- a/app/Http/Controllers/BibliographyController.php
+++ b/app/Http/Controllers/BibliographyController.php
@@ -8,6 +8,7 @@ use Illuminate\Support\Facades\DB;
 use RenanBr\BibTexParser\Listener;
 use RenanBr\BibTexParser\Exception\ParserException;
 use RenanBr\BibTexParser\Parser;
+use RenanBr\BibTexParser\Processor\TagNameCaseProcessor;
 
 class BibliographyController extends Controller
 {
@@ -93,6 +94,12 @@ class BibliographyController extends Controller
         $file = $request->file('file');
         $noOverwriteOnDup = $request->input('no-overwrite', false);
         $listener = new Listener();
+        $listener->addProcessor(new TagNameCaseProcessor(CASE_LOWER));
+        $listener->addProcessor(function($entry) {
+            $entry['_type'] = strtolower($entry['_type']);
+            $entry['type'] = strtolower($entry['type']);
+            return $entry;
+        });
         $parser = new Parser();
         $parser->addListener($listener);
         try {

--- a/resources/js/components/BibliographyTable.vue
+++ b/resources/js/components/BibliographyTable.vue
@@ -63,6 +63,7 @@
                             v-model="state.files"
                             class="btn btn-sm btn-outline-primary clickable"
                             accept=".bib,.bibtex,application/x-bibtex,text/x-bibtex,text/plain"
+                            extensions="bib,bibtex"
                             :custom-action="importFile"
                             :directory="false"
                             :disabled="!can('bibliography_write|bibliography_create')"

--- a/resources/js/components/BibliographyTable.vue
+++ b/resources/js/components/BibliographyTable.vue
@@ -62,8 +62,7 @@
                             ref="upload"
                             v-model="state.files"
                             class="btn btn-sm btn-outline-primary clickable"
-                            accept="application/x-bibtex,text/x-bibtex,text/plain"
-                            extensions="bib,bibtex"
+                            accept=".bib,.bibtex,application/x-bibtex,text/x-bibtex,text/plain"
                             :custom-action="importFile"
                             :directory="false"
                             :disabled="!can('bibliography_write|bibliography_create')"
@@ -632,7 +631,7 @@
                 // Enable automatic upload
                 if(!!newFile && (Boolean(newFile) !== Boolean(oldFile) || oldFile.error !== newFile.error)) {
                     if(!newFile.active) {
-                        newFile.active = true
+                        newFile.active = true;
                     }
                 }
             };
@@ -750,7 +749,7 @@
 
             const formatBibtexAndShowHighlight = text => {
                 if(!text) return '';
-                text = formatBibtexText(text)
+                text = formatBibtexText(text);
                 return highlight(text, state.query);
             };
 
@@ -776,5 +775,5 @@
                 state,
             };
         },
-    }
+    };
 </script>


### PR DESCRIPTION
Fixing the file explorer not showing .bib and .bibtex files on windows.
Somehow the 'extension' prop of the file-upload component was not applied.
So I added it to the accept prop (which shold be internally merged anyways, as it is the
only available attribute on the input element where it has an effect).

Tested on Windows and MacOs.