### PR TITLE
add offset to overlay

### DIFF
--- a/resources/js/components/map/InteractiveMap.vue
+++ b/resources/js/components/map/InteractiveMap.vue
@@ -914,7 +914,7 @@
                 actionState.measure.tooltipElement = document.getElementById(actionState.popupIds.m);
                 actionState.measure.tooltip = new Overlay({
                     element: actionState.measure.tooltipElement,
-                    offset: [0, 5]
+                    offset: [0, -10]
                 });
                 state.map.addOverlay(actionState.measure.tooltip);
             };
@@ -1449,6 +1449,7 @@
                     actionState.overlay = new Overlay({
                         element: overlayElem,
                         positioning: 'bottom-center',
+                        offset: [0, -10],
                         autoPan: true,
                         autoPanAnimation: {
                             duration: 250,


### PR DESCRIPTION
Moves the offset a bit up that it is no longer clipping the point.

![image](https://github.com/DH-Center-Tuebingen/Spacialist/assets/7532600/2bd0532d-98eb-4eea-862c-bde9a587a56f)
