### PR TITLE
0.10.2 importer fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,13 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 - Fixed Date Range _importFrom_ to return a JSON string
+- Fixed Date Range component in the frontend
 
 ### Changed 
 - Added tests to _ApiDataImporterTest_ to check if the same columns can be used in multiple attributes
 - Added in testing data an attribute (_'Aufbewahrung' [string]_) to the entity type _'Fundstelle'_
 - Changed the row error from just sending the column name to also send the column value
+- Dropdowns in the _Data Importer_ are now sorted alphabetically, both the order of the attribute mappings and the option lists inside the dropdowns
 - The ErrorList component of the Data Importer in the Frontend now preserves text inside `{{...}}`
 
 ## 0.10.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,17 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## 0.10.2
+
+### Fixed
+- Fixed Date Range _importFrom_ to return a JSON string
+
+### Changed 
+- Added tests to _ApiDataImporterTest_ to check if the same columns can be used in multiple attributes
+- Added in testing data an attribute (_'Aufbewahrung' [string]_) to the entity type _'Fundstelle'_
+- Changed the row error from just sending the column name to also send the column value
+- The ErrorList component of the Data Importer in the Frontend now preserves text inside `{{...}}`
+
 ## 0.10.1
 ### Added
 - Option to display attributes in _Data Model Editor_ in groups

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,16 +2,11 @@
 All notable changes to this project will be documented in this file.
 
 ## 0.10.2
-
-### Fixed
-- Fixed Date Range _importFrom_ to return a JSON string
-- Fixed Date Range component in the frontend
-
-### Changed 
+### Changed
+- Date Range _importFrom_ returns a JSON string
 - Added tests to _ApiDataImporterTest_ to check if the same columns can be used in multiple attributes
-- Added in testing data an attribute (_'Aufbewahrung' [string]_) to the entity type _'Fundstelle'_
-- Changed the row error from just sending the column name to also send the column value
-- Dropdowns in the _Data Importer_ are now sorted alphabetically, both the order of the attribute mappings and the option lists inside the dropdowns
+- Row error now also sends the column value, instead of just sending the column name
+- Dropdowns in the _Data Importer_ are now sorted alphabetically
 - The ErrorList component of the Data Importer in the Frontend now preserves text inside `{{...}}`
 
 ## 0.10.1
@@ -23,8 +18,8 @@ All notable changes to this project will be documented in this file.
   - selects the first choice (if there is **only one choice** in the dropdown)*
   - selects the exact match (**case insensitive**; e.g. "apple" + `Tab` will select the available choice "apple", but also "Apple")*
   - nothing and focuses the next attribute (default)
-  - * Selected elements will be marked with a blue (Tab) badge 
-- Pressing `Delete` inside _Single Choice Dropdowns_ will clear the element  
+  - * Selected elements will be marked with a blue (Tab) badge
+- Pressing `Delete` inside _Single Choice Dropdowns_ will clear the element
 - Importer now automatically removes BOM if present
 - Better readable format for error message on validation
 - Renamed _fromImport_ to _parseImport_ on the attribute classses. The base class now by default imports the passed string, removing redundancies on the string-based classes.

--- a/app/AttributeTypes/DaterangeAttribute.php
+++ b/app/AttributeTypes/DaterangeAttribute.php
@@ -29,10 +29,10 @@ class DaterangeAttribute extends AttributeBase
             throw InvalidDataException::requireBefore($start, $end);
         }
 
-        return [
+        return json_encode([
             "start" => $start,
             "end" => $end,
-        ];
+        ]);
     }
 
     public static function unserialize(mixed $data) : mixed {

--- a/app/AttributeTypes/DaterangeAttribute.php
+++ b/app/AttributeTypes/DaterangeAttribute.php
@@ -30,8 +30,8 @@ class DaterangeAttribute extends AttributeBase
         }
 
         return json_encode([
-            "start" => $start,
-            "end" => $end,
+            $start,
+            $end,
         ]);
     }
 

--- a/app/Import/EntityImporter.php
+++ b/app/Import/EntityImporter.php
@@ -25,7 +25,7 @@ class EntityImporter {
 
     private $metadata;
     private array $attributesMap;
-    private array $attributeAttributeMap = [];
+    private array $attributeIdToAttributeValue = [];
     private int $entityTypeId;
     private string $nameColumn;
     private ?string $parentColumn = null;
@@ -147,7 +147,7 @@ class EntityImporter {
     private function verifyAttributeMapping($headers): bool {
         $nameErrors = [];
         $indexErrors = [];
-        foreach($this->attributesMap as $attribute => $column) {
+        foreach($this->attributesMap as $attributeId => $column) {
             $column = trim($column);
             if($column == "") {
                 continue;
@@ -157,27 +157,26 @@ class EntityImporter {
                 array_push($nameErrors, $column);
             }
 
-            $attr = Attribute::find($attribute);
+            $attr = Attribute::find($attributeId);
             if(!$attr) {
-                array_push($indexErrors, $attribute);
+                array_push($indexErrors, $attributeId);
             } else {
-                $this->attributeAttributeMap[$column] = $attr;
+                $this->attributeIdToAttributeValue[$attributeId] = $attr;
             }
         }
 
+        $valid = true;
         if(count($indexErrors) > 0) {
             $this->resolver->conflict(__("entity-importer.attribute-id-does-not-exist", ["attributes" => implode(", ", $indexErrors)]));
+            $valid = false;
         }
 
         if(count($nameErrors) > 0) {
             $this->resolver->conflict(__("entity-importer.attribute-column-does-not-exist", ["columns" => implode(", ", $nameErrors)]));
+            $valid = false;
         }
 
-        if(count($indexErrors) > 0 || count($nameErrors) > 0) {
-            return false;
-        } else {
-            return true;
-        }
+        return $valid;
     }
 
     private function validateName($row, $rowIndex): bool {
@@ -233,18 +232,22 @@ class EntityImporter {
 
     private function validateAttributesInRow($row, $index): bool {
         $errors = [];
-        foreach($this->attributeAttributeMap as $column => $attribute) {
+        foreach($this->attributeIdToAttributeValue as $attributeId => $attribute) {
             try {
+                $column = $this->attributesMap[$attributeId];
                 $datatype = $attribute->datatype;
                 $attrClass = AttributeBase::getMatchingClass($datatype);
                 $attrClass::fromImport($row[$column]);
             } catch(Exception $e) {
-                array_push($errors, $column);
+                array_push($errors, ["column" => $column, "value" => $row[$column]]);
             }
         }
 
         if(count($errors) > 0) {
-            $this->rowConflict($index, "entity-importer.attribute-could-not-be-imported", ["attribute" => implode(", ", $errors)]);
+            $errorStrings = array_map(function ($error) {
+                return "{{" . $error['column'] . "}}" . " => " . "{{" . $error['value'] . "}}";
+            }, $errors);
+            $this->rowConflict($index, "entity-importer.attribute-could-not-be-imported", ["attributeErrors" => implode(", ", $errorStrings)]);
         }
         return count($errors) == 0;
     }

--- a/database/seeders/EntityAttributesTableSeeder.php
+++ b/database/seeders/EntityAttributesTableSeeder.php
@@ -54,7 +54,7 @@ class EntityAttributesTableSeeder extends Seeder
                 'updated_at' => '2017-12-20 17:01:58',
                 'position' => 2,
                 'depends_on' => NULL,
-            ),
+            ),            
             4 =>
             array (
                 'id' => 18,
@@ -245,6 +245,16 @@ class EntityAttributesTableSeeder extends Seeder
                 'position' => 6,
                 'depends_on' => NULL,
             ),
+            23 =>             
+            array (
+                'id' => 26,
+                'entity_type_id' => 3, // Fundstelle
+                'attribute_id' => 19, // Aufbewahrung [string]
+                'created_at' => '2017-12-20 17:00:43',
+                'updated_at' => '2017-12-20 17:01:58',
+                'position' => 3,
+                'depends_on' => NULL,
+            ),   
         ));
     }
 }

--- a/database/seeders/EntityAttributesTableSeeder.php
+++ b/database/seeders/EntityAttributesTableSeeder.php
@@ -54,7 +54,7 @@ class EntityAttributesTableSeeder extends Seeder
                 'updated_at' => '2017-12-20 17:01:58',
                 'position' => 2,
                 'depends_on' => NULL,
-            ),            
+            ),
             4 =>
             array (
                 'id' => 18,
@@ -245,7 +245,7 @@ class EntityAttributesTableSeeder extends Seeder
                 'position' => 6,
                 'depends_on' => NULL,
             ),
-            23 =>             
+            23 =>
             array (
                 'id' => 26,
                 'entity_type_id' => 3, // Fundstelle
@@ -254,7 +254,7 @@ class EntityAttributesTableSeeder extends Seeder
                 'updated_at' => '2017-12-20 17:01:58',
                 'position' => 3,
                 'depends_on' => NULL,
-            ),   
+            ),
         ));
     }
 }

--- a/lang/de/entity-importer.php
+++ b/lang/de/entity-importer.php
@@ -1,4 +1,3 @@
-
 <?php
 
 return [
@@ -6,6 +5,9 @@ return [
     'file-not-found' => 'Datei konnte nicht gelesen werden.',
     'missing-data' => 'Benötigte Spalte fehlt: :column',
     'invalid-data' => 'Ungültige Daten: [:column] => :value',
+    'attribute-could-not-be-imported' => 'Attribut konnte nicht importiert werden: :attributeErrors',
+    'attribute-id-does-not-exist' => 'Die Attribut-ID existiert nicht: :attributes',
+    'attribute-column-does-not-exist' => 'Die Attribut-Spalten existieren nicht: :columns',
     'name-column-does-not-exist' => 'Die Spalte für den Namen existiert nicht: :column',
     'parent-column-does-non-exist' => 'Die Spalte für die Eltern-Entität existiert nicht: :column',
     'parent-entity-does-not-exist' => 'Die Eltern-Entität existiert nicht: :entity',

--- a/lang/en/entity-importer.php
+++ b/lang/en/entity-importer.php
@@ -5,7 +5,7 @@ return [
     'file-not-found' => 'File could not be read.',
     'missing-data' => 'Required column is missing: :column',
     'invalid-data' => 'Invalid data: [:column] => :value',
-    'attribute-could-not-be-imported' => 'Attribute could not be imported: :attribute',
+    'attribute-could-not-be-imported' => 'Attribute could not be imported: :attributeErrors',
     'attribute-id-does-not-exist' => 'The attribute id does not exist: :attributes',
     'attribute-column-does-not-exist' => 'The attribute columns do not exist: :columns',
     'name-column-does-not-exist' => 'The column for the name does not exist: :column',

--- a/resources/js/components/attribute/Daterange.vue
+++ b/resources/js/components/attribute/Daterange.vue
@@ -1,4 +1,3 @@
- 
 <template>
     <date-picker
         :id="name"
@@ -59,14 +58,12 @@
                 disabled,
                 value,
             } = toRefs(props);
-            // FETCH
 
-            
-            const fixValue = _ => {                
+            // FETCH
+            const fixValue = _ => {
                 return value.value?.map(dt => new Date(dt));
             };
-            
-            
+
             const resetFieldState = _ => {
                 v.resetField({
                     value: fixValue(),
@@ -103,7 +100,6 @@
                 meta,
                 resetField,
             });
-
 
             watch(_ => value, (newValue, oldValue) => {
                 resetFieldState();

--- a/resources/js/components/attribute/Daterange.vue
+++ b/resources/js/components/attribute/Daterange.vue
@@ -46,6 +46,9 @@
             },
             value: {
                 type: Array,
+                validator: arr => {
+                    return !arr || arr.length === 2;
+                },
                 required: true,
             },
         },
@@ -58,13 +61,15 @@
             } = toRefs(props);
             // FETCH
 
-            // FUNCTIONS
-            const strToDate = str => {
-                return new Date(str);
+            
+            const fixValue = _ => {                
+                return value.value?.map(dt => new Date(dt));
             };
+            
+            
             const resetFieldState = _ => {
                 v.resetField({
-                    value: value.value?.map(dt => strToDate(dt)),
+                    value: fixValue(),
                 });
             };
             const undirtyField = _ => {
@@ -78,7 +83,7 @@
                     return new Date(date.getTime() - (date.getTimezoneOffset()*60*1000));
                 });
                 v.handleChange(correctValue);
-            }
+            };
 
             // DATA
             const {
@@ -87,7 +92,7 @@
                 meta,
                 resetField,
             } = useField(`daterange_${name.value}`, yup.array(), {
-                initialValue: value.value?.map(dt => strToDate(dt)),
+                initialValue: fixValue(),
             });
             const state = reactive({
 

--- a/resources/js/components/error/ErrorList.vue
+++ b/resources/js/components/error/ErrorList.vue
@@ -63,7 +63,6 @@
                     }
                     return result;
                 });
-                console.log(lines);
                 return lines;
             });
 

--- a/resources/js/components/error/ErrorList.vue
+++ b/resources/js/components/error/ErrorList.vue
@@ -35,22 +35,40 @@
                 required: true
             }
         },
-        setup(props){
+        setup(props) {
             const header = computed(_ => {
                 return props.value.split(props.headerSeparator)[0].trim();
             });
 
             const items = computed(_ => {
 
-                const headerParts = props.value.split(props.headerSeparator);
-                headerParts.shift();
+                // Replace text inside double curly braces with placeholders
+                const preservationRegex = RegExp('{{(.*?)}}', 'g');
+                const variables = {};
+                let counter = 1;
+                const preservationMatches = props.value.replace(preservationRegex, (match, p1 = '') => {
+                    const key = `$${counter++}`;
+                    variables[key] = p1;
+                    return key;
+                });
+                
+                const [header, ...body] = preservationMatches.split(props.headerSeparator);
 
-                const parts = headerParts.join(props.separator);
-                return parts.split(props.separator);
+                const joinedBody = body.join(props.headerSeparator).trim();
+                let lines = joinedBody.split(props.separator);
+                lines = lines.map((line, idx) => {
+                    let result = line;
+                    for(const [key, value] of Object.entries(variables)) {
+                        result = result.replace(key, value);
+                    }
+                    return result;
+                });
+                console.log(lines);
+                return lines;
             });
 
             const hasItems = computed(_ => {
-                return items.value.length > 0 && items.value[0].trim() !== '';
+                return items.value.length > 0 && items.value[0] && items.value[0].trim() !== '';
             });
 
 

--- a/resources/js/components/error/ErrorList.vue
+++ b/resources/js/components/error/ErrorList.vue
@@ -41,7 +41,6 @@
             });
 
             const items = computed(_ => {
-
                 // Replace text inside double curly braces with placeholders
                 const preservationRegex = RegExp('{{(.*?)}}', 'g');
                 const variables = {};
@@ -51,7 +50,7 @@
                     variables[key] = p1;
                     return key;
                 });
-                
+
                 const [header, ...body] = preservationMatches.split(props.headerSeparator);
 
                 const joinedBody = body.join(props.headerSeparator).trim();
@@ -70,11 +69,10 @@
                 return items.value.length > 0 && items.value[0] && items.value[0].trim() !== '';
             });
 
-
             return {
                 hasItems,
                 header,
-                items
+                items,
             };
         }
     };

--- a/resources/js/components/tools/importer/EntityAttributeMapping.vue
+++ b/resources/js/components/tools/importer/EntityAttributeMapping.vue
@@ -7,7 +7,7 @@
             {{ t('main.importer.info.entity_type_has_no_attributes') }}
         </div>
         <div
-            v-for="(attr, i) in availableAttributes"
+            v-for="(attr, i) in availableAttributesSortedByName"
             :key="i"
             class="attribute-mapping-item"
         >
@@ -20,7 +20,7 @@
                     class="form-label"
                     :for="`input-data-column-${attr.id}`"
                 >
-                    {{ translateConcept(attr.thesaurus_url) }}
+                    {{ attr._name }}
                     <span class="ms-2 opacity-50 small">
                         {{ t(`global.attributes.${attr.datatype}`) }}
                     </span>
@@ -31,9 +31,7 @@
                 :disabled="disabled"
                 :value="attributeMapping[attr.id]"
                 :classes="multiselectResetClasslist"
-                :object="false"
-                :mode="'single'"
-                :options="availableColumns"
+                :options="sortedOptions"
                 :placeholder="t('global.select.placeholder')"
                 :hide-selected="true"
                 :searchable="true"
@@ -54,6 +52,7 @@
     } from '@/helpers/helpers.js';
 
     import ValuesMissingIndicator from './ValuesMissingIndicator.vue';
+    import { computed } from 'vue';
 
     export default {
         components: {
@@ -127,16 +126,38 @@
                 return val;
             }
 
+            const availableAttributesSortedByName = computed(_ => {
+                let arr = [];
+                for(const attr of props.availableAttributes) {
+                    arr.push({
+                        ...attr,
+                        _name: translateConcept(attr.thesaurus_url),
+                    });
+                }
+
+                return arr.sort((a, b) => {
+                    return a._name.localeCompare(b._name);
+                });
+            });
+
+            const sortedOptions = computed(_ => {
+                return props.availableColumns.toSorted((a, b) => {
+                    return a.localeCompare(b);
+                });
+            });
+
             return {
                 t,
                 translateConcept,
-                multiselectResetClasslist,
-                updateAttributeMapping,
+                // Local
+                availableAttributesSortedByName,
                 deselectWorkAround,
-                getTotal,
                 getMissing,
+                getTotal,
+                multiselectResetClasslist,
+                sortedOptions,
+                updateAttributeMapping,
             };
         },
     };
 </script>
-

--- a/resources/js/components/tools/importer/EntityAttributeMapping.vue
+++ b/resources/js/components/tools/importer/EntityAttributeMapping.vue
@@ -44,6 +44,7 @@
 </template>
 
 <script>
+    import { computed } from 'vue';
     import { useI18n } from 'vue-i18n';
 
     import {
@@ -52,7 +53,6 @@
     } from '@/helpers/helpers.js';
 
     import ValuesMissingIndicator from './ValuesMissingIndicator.vue';
-    import { computed } from 'vue';
 
     export default {
         components: {
@@ -83,48 +83,47 @@
         emits: [
             'row-changed',
             'update:attributeMapping',
-        ], setup(props, context) {
-            const {
-                t
-            } = useI18n();
+        ],
+        setup(props, context) {
+            const { t } = useI18n();
 
-            function updateAttributeMapping(id, option) {
+            const updateAttributeMapping = (id, option) => {
                 const newMapping = Object.assign({}, props.attributeMapping);
                 newMapping[id] = option;
 
                 context.emit('row-changed', id, option);
                 context.emit('update:attributeMapping', newMapping);
-            }
+            };
 
-            function deselectWorkAround(id, value) {
+            const deselectWorkAround = (id, value) => {
                 /**
                  * There is a deselect function for multiselect.
                  * But for some reason it's not fired when the user deselects an option.
-                 * So we use the change listener and only call the update function 
+                 * So we use the change listener and only call the update function
                  * when the value is set to 'null'.
                  */
                 if(value === null) {
                     updateAttributeMapping(id, null);
                 }
-            }
+            };
 
-            function getTotal(attr) {
+            const getTotal = attr => {
                 let val = 0;
                 const stat = props.stats.attributes[attr.id];
                 if(stat && stat.total) {
                     val = stat.total;
                 }
                 return val;
-            }
+            };
 
-            function getMissing(attr) {
+            const getMissing = attr => {
                 let val = 0;
                 const stat = props.stats.attributes[attr.id];
                 if(stat && stat.total) {
                     val = stat.missing;
                 }
                 return val;
-            }
+            };
 
             const availableAttributesSortedByName = computed(_ => {
                 let arr = [];
@@ -148,7 +147,6 @@
 
             return {
                 t,
-                translateConcept,
                 // Local
                 availableAttributesSortedByName,
                 deselectWorkAround,

--- a/resources/js/components/tools/importer/EntityImporterSettings.vue
+++ b/resources/js/components/tools/importer/EntityImporterSettings.vue
@@ -90,8 +90,8 @@
 </template>
 
 <script>
-    import { useI18n } from 'vue-i18n';
     import { computed } from 'vue';
+    import { useI18n } from 'vue-i18n';
 
     import {
         multiselectResetClasslist,
@@ -136,24 +136,23 @@
         },
         emits: ['update:entityType', 'update:entityName', 'update:entityParent'],
         setup(props) {
-
             const { t } = useI18n();
 
-            function getTotal(attr) {
+            const getTotal = attr => {
                 let val = 0;
                 if(props.stats[attr]?.total != undefined)
                     val = props.stats[attr].total;
                 return val;
             }
 
-            function getMissing(attr) {
+            const getMissing = attr => {
                 let val = 0;
                 if(props.stats[attr]?.missing != undefined)
                     val = props.stats[attr].missing;
                 return val;
             }
 
-            const sortedAvailableEntityTypes = computed(() => {
+            const sortedAvailableEntityTypes = computed(_ => {
                 const options = props.availableEntityTypes;
                 for(const option of options) {
                     option._label = translateConcept(option.thesaurus_url);
@@ -164,7 +163,7 @@
                 });
             });
 
-            const sortedAvailableColumns = computed(() => {
+            const sortedAvailableColumns = computed(_ => {
                 const options = [];
                 for(const key in props.availableColumns) {
                     options.push(props.availableColumns[key]);
@@ -178,7 +177,6 @@
             return {
                 t,
                 multiselectResetClasslist,
-                translateConcept,
                 getTotal,
                 getMissing,
                 sortedAvailableColumns,

--- a/resources/js/components/tools/importer/EntityImporterSettings.vue
+++ b/resources/js/components/tools/importer/EntityImporterSettings.vue
@@ -14,7 +14,7 @@
                 :hide-selected="true"
                 :label="'thesaurus_url'"
                 :object="true"
-                :options="availableEntityTypes"
+                :options="sortedAvailableEntityTypes"
                 :placeholder="t('global.select.placeholder')"
                 :searchable="true"
                 :track-by="'id'"
@@ -24,11 +24,11 @@
                 @change="value => $emit('update:entityType', value)"
             >
                 <template #option="{ option }">
-                    {{ translateConcept(option.thesaurus_url) }}
+                    {{ option._label }}
                 </template>
                 <template #singlelabel="{ value }">
                     <div class="multiselect-single-label">
-                        {{ translateConcept(value.thesaurus_url) }}
+                        {{ value._label }}
                     </div>
                 </template>
             </multiselect>
@@ -53,7 +53,7 @@
                 :classes="multiselectResetClasslist"
                 :disabled="disabled"
                 :hide-selected="true"
-                :options="availableColumns"
+                :options="sortedAvailableColumns"
                 :placeholder="t('global.select.placeholder')"
                 :searchable="true"
                 :value="entityName"
@@ -79,7 +79,7 @@
                 :disabled="disabled"
                 :hide-selected="true"
                 :value="entityParent"
-                :options="availableColumns"
+                :options="sortedAvailableColumns"
                 :placeholder="t('global.select.placeholder')"
                 :searchable="true"
                 :append-to-body="true"
@@ -91,6 +91,7 @@
 
 <script>
     import { useI18n } from 'vue-i18n';
+    import { computed } from 'vue';
 
     import {
         multiselectResetClasslist,
@@ -152,12 +153,36 @@
                 return val;
             }
 
+            const sortedAvailableEntityTypes = computed(() => {
+                const options = props.availableEntityTypes;
+                for(const option of options) {
+                    option._label = translateConcept(option.thesaurus_url);
+                }
+
+                return options.sort((a, b) => {
+                    return a._label.localeCompare(b._label);
+                });
+            });
+
+            const sortedAvailableColumns = computed(() => {
+                const options = [];
+                for(const key in props.availableColumns) {
+                    options.push(props.availableColumns[key]);
+                }
+
+                return Object.values(options).sort((a, b) => {
+                    return a.localeCompare(b);
+                });
+            });
+
             return {
                 t,
                 multiselectResetClasslist,
                 translateConcept,
                 getTotal,
                 getMissing,
+                sortedAvailableColumns,
+                sortedAvailableEntityTypes,
             };
         },
     };

--- a/tests/Feature/ApiDataImporterTest.php
+++ b/tests/Feature/ApiDataImporterTest.php
@@ -464,7 +464,7 @@ class ApiDataImporterTest extends TestCase {
         ])
             ->assertStatus(200)
             ->assertJson([
-                'errors' => ['[2] Attribute could not be imported: Abmessungen'],
+                'errors' => ['[2] Attribute could not be imported: {{Abmessungen}} => {{1,2,3,cm}}'],
                 'summary' => [
                     'create' => 1,
                     'update' => 0,
@@ -472,7 +472,29 @@ class ApiDataImporterTest extends TestCase {
                 ]
             ]);
     }
+    
+    public function testValidationWithDuplicateColumnMapping(){
+        $response = $this->userRequest()->post('/api/v1/entity/import/validate', [
+            'file' => $this->createDefaultCSVFile(),
+            'data' => $this->getData(
+                attributes: [
+                    13 => "Notizen", // Notizen
+                    19 => "Notizen", // Aufbewahrung
+                ]
+            ),
+            'metadata' => $this->getMetaData(),
+        ]);
+        $response->assertStatus(200);
 
+        $response->assertJson([
+            'errors' => [],
+            'summary' => [
+                'create' => 4,
+                'update' => 1,
+                'conflict' => 0
+            ]
+        ]);
+    }
 
     public function testDataImportSuccess() {
         $response = $this->userRequest()->post('/api/v1/entity/import', [
@@ -576,5 +598,21 @@ class ApiDataImporterTest extends TestCase {
                 'on_name' => null
             ]
         ]);
+    }
+    
+    public function testDataImportFailsWithDuplicateColumnMapping(){
+        $response = $this->userRequest()->post('/api/v1/entity/import', [
+            'file' => $this->createDefaultCSVFile(),
+            'data' => $this->getData(
+                attributes: [
+                    13 => "Notizen", // Notizen
+                    19 => "Notizen", // Aufbewahrung
+                ]
+            ),
+            'metadata' => $this->getMetaData(),
+        ])
+            ->assertStatus(201);
+
+            
     }
 }

--- a/tests/Feature/ApiDataImporterTest.php
+++ b/tests/Feature/ApiDataImporterTest.php
@@ -7,12 +7,10 @@ use Tests\TestCase;
 use Illuminate\Http\UploadedFile;
 
 class ApiDataImporterTest extends TestCase {
-
-
     /**
-     * 
+     *
      * Utilities
-     * 
+     *
      */
     private function createDefaultCSVFile($delimiter = ",") {
         return $this->createCSVFile([
@@ -74,11 +72,10 @@ class ApiDataImporterTest extends TestCase {
     }
 
     /**
-     * 
+     *
      * Tests
-     * 
+     *
      */
-
     public function testValidationEmptyFile() {
         $file = $this->createCSVFile([]);
         $metadata = $this->getMetaData();
@@ -122,7 +119,6 @@ class ApiDataImporterTest extends TestCase {
             ]);
     }
 
-
     public function testValidationNamesColumnMissingError() {
         $file = $this->createCSVFile([['other'], [''], ['other 2']]);
 
@@ -164,7 +160,6 @@ class ApiDataImporterTest extends TestCase {
             ]
         ]);
     }
-
 
     public function testValidationWithAllNamesSetCorrectly() {
         $this->userRequest()->post('/api/v1/entity/import/validate', [
@@ -217,8 +212,6 @@ class ApiDataImporterTest extends TestCase {
             ]);
     }
 
-
-
     public function testValidationIncorrectDelimiter() {
         $this->userRequest()->post('/api/v1/entity/import/validate', [
             'file' => $this->createDefaultCSVFile(';'),
@@ -235,7 +228,6 @@ class ApiDataImporterTest extends TestCase {
                 ]
             ]);
     }
-
 
     public function testValidationCorrectDelimiter() {
         $this->userRequest()->post('/api/v1/entity/import/validate', [
@@ -254,7 +246,6 @@ class ApiDataImporterTest extends TestCase {
             ]);
     }
 
-
     public function testValidationWithParentColumn() {
         $this->userRequest()->post('/api/v1/entity/import/validate', [
             'file' => $this->createDefaultCSVFile(),
@@ -271,7 +262,6 @@ class ApiDataImporterTest extends TestCase {
                 ]
             ]);;
     }
-
 
     public function testValidationWithParentColumnChildTypeNotAllowed() {
         $file = $this->createCSVFile([
@@ -317,7 +307,6 @@ class ApiDataImporterTest extends TestCase {
             ]);
     }
 
-
     public function testValidationWithParentColumnSubElementAlreadyExists() {
         $file = $this->createCSVFile([
             ['name', 'parent', 'Notizen'],
@@ -359,7 +348,6 @@ class ApiDataImporterTest extends TestCase {
                 ]
             ]);
     }
-
 
     public function testValidationOfAttributesInvalidColumnName() {
         $this->userRequest()->post('/api/v1/entity/import/validate', [
@@ -472,7 +460,7 @@ class ApiDataImporterTest extends TestCase {
                 ]
             ]);
     }
-    
+
     public function testValidationWithDuplicateColumnMapping(){
         $response = $this->userRequest()->post('/api/v1/entity/import/validate', [
             'file' => $this->createDefaultCSVFile(),
@@ -508,10 +496,7 @@ class ApiDataImporterTest extends TestCase {
                 'error' => 'any'
             ]);
         }
-
         $response->assertStatus(201);
-
-
 
         $entityId = null;
         try {
@@ -599,7 +584,7 @@ class ApiDataImporterTest extends TestCase {
             ]
         ]);
     }
-    
+
     public function testDataImportFailsWithDuplicateColumnMapping(){
         $response = $this->userRequest()->post('/api/v1/entity/import', [
             'file' => $this->createDefaultCSVFile(),
@@ -612,7 +597,5 @@ class ApiDataImporterTest extends TestCase {
             'metadata' => $this->getMetaData(),
         ])
             ->assertStatus(201);
-
-            
     }
 }


### PR DESCRIPTION
### Fixed
- Fixed Date Range _importFrom_ to return a JSON string
- Fixed Date Range component in the frontend

### Changed 
- Added tests to _ApiDataImporterTest_ to check if the same columns can be used in multiple attributes
- Added in testing data an attribute (_'Aufbewahrung' [string]_) to the entity type _'Fundstelle'_
- Changed the row error from just sending the column name to also send the column value
- Dropdowns in the _Data Importer_ are now sorted alphabetically, both the order of the attribute mappings and the option lists inside the dropdowns
- The ErrorList component of the Data Importer in the Frontend now preserves text inside `{{...}}`