### PR TITLE
Fixed importer when header is not present and row numbers are used.

### DIFF
--- a/app/Exceptions/CsvColumnMismatchException.php
+++ b/app/Exceptions/CsvColumnMismatchException.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Exceptions;
+
+use Exception;
+
+class CsvColumnMismatchException extends Exception {
+    public $headerLine;
+    public $dataLine;
+    public $headerColumns;
+    public $dataColumns;
+
+    public function __construct(string $headerLine, string $dataLine, int $headerColumns, int $dataColumns) {
+        $this->headerLine = $headerLine;
+        $this->dataLine = $dataLine;
+        $this->headerColumns = $headerColumns;
+        $this->dataColumns = $dataColumns;
+    }
+}

--- a/app/Exceptions/Structs/AttributeImportExceptionStruct.php
+++ b/app/Exceptions/Structs/AttributeImportExceptionStruct.php
@@ -5,7 +5,6 @@ namespace App\Exceptions\Structs;
 use JsonSerializable;
 
 class AttributeImportExceptionStruct implements JsonSerializable {
-
     public $type;
     public $columnIndex;
     public $columnName;

--- a/app/File/Csv.php
+++ b/app/File/Csv.php
@@ -31,9 +31,9 @@ class Csv extends Parser {
         $rowIndex = 0;
         $this->rows = 0;
         // We don't use the fgetcsvfunction to change the file encoding to UTF-8.
-        while (($row = fgets($fileHandle)) !== false) {
+        while(($row = fgets($fileHandle)) !== false) {
             $this->rows++;
-            if ($this->hasHeaderRow && $rowIndex === 0) {
+            if($this->hasHeaderRow && $rowIndex === 0) {
                 $rowIndex++;
                 continue;
             }
@@ -58,11 +58,11 @@ class Csv extends Parser {
         $headers = null;
 
         $row = fgets($fileHandle);
-        if (!$row) {
+        if(!$row) {
             throw new \Exception("File is empty.");
         }
 
-        if ($this->hasHeaderRow) {
+        if($this->hasHeaderRow) {
             $utf8Line = $this->toUtf8($row);
             $headers = $this->fromCsvLine($utf8Line);
             $headers = array_map(fn ($header) => trim($header), $headers);
@@ -77,8 +77,8 @@ class Csv extends Parser {
 
     private function generateNumberHeaders($row) {
         $headers = [];
-
-        for ($i = 1; $i <= count($row); $i++) {
+        $parts = explode($this->delimiter, $row);
+        for($i = 1; $i <= count($parts); $i++) {
             $headers[] = "#$i";
         }
 
@@ -92,14 +92,14 @@ class Csv extends Parser {
      * @return array $row - Associative array using the headers as keys and the values from the line as values
      */
     private function parseRow($line) {
-        if (empty($this->headers)) {
+        if(empty($this->headers)) {
             throw new \Exception("Headers are not set. Run parseHeaders first.");
         }
 
         $row = [];
 
         $arr = $this->fromCsvLine($line);
-        for ($i = 0; $i < count($arr); $i++) {
+        for($i = 0; $i < count($arr); $i++) {
             $row[$this->headers[$i]] = trim($arr[$i]);
         }
         return $row;
@@ -113,10 +113,10 @@ class Csv extends Parser {
      * @return array|string $data - The converted data
      */
     private function toUtf8(array|string $data): array|string {
-        if ($this->isUtf8()) return $data;
+        if($this->isUtf8()) return $data;
 
         $tgt = 'UTF-8';
-        if (is_array($data)) {
+        if(is_array($data)) {
             $data = array_map(fn ($str) => iconv($this->encoding, $tgt, $str), $data);
         } else {
             $data = iconv($this->encoding, $tgt, $data);
@@ -147,7 +147,7 @@ class Csv extends Parser {
     }
 
     private function verifyColumnExists($column) {
-        if (!in_array($column, $this->headers)) {
+        if(!in_array($column, $this->headers)) {
             throw new \Exception("Column '$column' does not exist.");
         }
     }

--- a/app/File/Csv.php
+++ b/app/File/Csv.php
@@ -2,11 +2,13 @@
 
 namespace App\File;
 
-class Csv extends Parser {
+use App\Exceptions\CsvColumnMismatchException;
 
+class Csv extends Parser {
     private string $delimiter;
     private bool $hasHeaderRow;
     private array $headers = [];
+    private int $headerCount = 0;
     private string $encoding = 'UTF-8';
     private int $rows = 0;
 
@@ -16,21 +18,20 @@ class Csv extends Parser {
         $this->encoding = $encoding;
     }
 
-    public function getHeaders() {
+    public function getHeaders(): array {
         return $this->headers;
     }
 
-
-
     /**
      * Parses a CSV file.
-     * 
+     *
      * @param resource $fileHandle - The file handle to the CSV file
+     * @param callable $$rowCallback -
      */
-    public function parse($fileHandle, $rowCallback) {
+    public function parse($fileHandle, callable $rowCallback): void {
         $rowIndex = 0;
         $this->rows = 0;
-        // We don't use the fgetcsvfunction to change the file encoding to UTF-8.
+        // We don't use the fgetcsv function to change the file encoding to UTF-8.
         while(($row = fgets($fileHandle)) !== false) {
             $this->rows++;
             if($this->hasHeaderRow && $rowIndex === 0) {
@@ -47,14 +48,14 @@ class Csv extends Parser {
 
     /**
      * Gets the headers from the CSV file.
-     * 
+     *
      * If there is no header (hasHeaderRow = false), it will return an array of numbers (1, 2, 3, ...)
      * and the array will not be changed.
-     * 
-     * @param array $lines - The lines of the CSV file
+     *
+     * @param resource $lines - The lines of the CSV file
      * @return array $headers - The headers of the CSV file
      */
-    public function parseHeaders($fileHandle) {
+    public function parseHeaders($fileHandle): array {
         $headers = null;
 
         $row = fgets($fileHandle);
@@ -69,15 +70,17 @@ class Csv extends Parser {
         } else {
             $headers = $this->generateNumberHeaders($row);
         }
+        $this->headerCount = count($headers);
 
         rewind($fileHandle);
         $this->headers = $headers;
         return $headers;
     }
 
-    private function generateNumberHeaders($row) {
+    private function generateNumberHeaders(string $row): array {
         $headers = [];
-        $parts = explode($this->delimiter, $row);
+        // $parts = explode($this->delimiter, $row);
+        $parts = $this->fromCsvLine($row);
         for($i = 1; $i <= count($parts); $i++) {
             $headers[] = "#$i";
         }
@@ -87,28 +90,33 @@ class Csv extends Parser {
 
     /**
      * Gets a single row from a CSV line string.
-     * 
+     *
      * @param string $line - The line from the CSV file
      * @return array $row - Associative array using the headers as keys and the values from the line as values
      */
-    private function parseRow($line) {
+    private function parseRow(string $line): array {
         if(empty($this->headers)) {
             throw new \Exception("Headers are not set. Run parseHeaders first.");
         }
 
         $row = [];
 
-        $arr = $this->fromCsvLine($line);
-        for($i = 0; $i < count($arr); $i++) {
-            $row[$this->headers[$i]] = trim($arr[$i]);
+        $cols = $this->fromCsvLine($line);
+        $colCount = count($cols);
+        if($this->headerCount != $colCount) {
+            $headerRow = implode($this->delimiter, $this->headers);
+            $dataRow = implode($this->delimiter, $cols);
+            throw new CsvColumnMismatchException($headerRow, $dataRow, $this->headerCount, $colCount);
+        }
+        for($i = 0; $i < $colCount; $i++) {
+            $row[$this->headers[$i]] = trim($cols[$i]);
         }
         return $row;
     }
 
-
     /**
      * Converts the data to UTF-8 if it is not already.
-     * 
+     *
      * @param array|string $data - The data to convert
      * @return array|string $data - The converted data
      */
@@ -129,12 +137,11 @@ class Csv extends Parser {
         return $this->encoding == 'UTF-8';
     }
 
-
-    public function getRows() {
+    public function getRows(): int {
         return $this->rows;
     }
 
-    public function getDataRows() {
+    public function getDataRows(): int {
         return $this->rows - ($this->hasHeaderRow ? 1 : 0);
     }
 
@@ -142,11 +149,11 @@ class Csv extends Parser {
      * Helper function to get the CSV from a line.
      * Always using the correct delimiter.
      */
-    private function fromCsvLine($line) {
+    private function fromCsvLine(string $line): array {
         return str_getcsv($line, separator: $this->delimiter);
     }
 
-    private function verifyColumnExists($column) {
+    private function verifyColumnExists(string $column): void {
         if(!in_array($column, $this->headers)) {
             throw new \Exception("Column '$column' does not exist.");
         }

--- a/app/File/Parser.php
+++ b/app/File/Parser.php
@@ -3,5 +3,5 @@
 namespace App\File;
 
 abstract class Parser {
-    abstract public function parse(string $filePath, callable $rowCallback);
+    abstract public function parse($filePath, callable $rowCallback);
 }

--- a/app/Import/ImportResolution.php
+++ b/app/Import/ImportResolution.php
@@ -2,7 +2,6 @@
 
 namespace App\Import;
 
-
 enum ImportResolutionType {
     case CREATE;
     case UPDATE;
@@ -10,7 +9,6 @@ enum ImportResolutionType {
 }
 
 class ImportResolution {
-
     private array $status;
     private array $errors = [];
 

--- a/lang/de/entity-importer.php
+++ b/lang/de/entity-importer.php
@@ -6,6 +6,7 @@ return [
     'file-not-found' => 'Datei konnte nicht gelesen werden.',
     'missing-data' => 'Benötigte Spalte fehlt: :column',
     'invalid-data' => 'Ungültige Daten: [:column] => :value',
+    'csv-column-mismatch' => 'Die Anzahl der Spalten in der aktuellen Zeile \':data\' (:data_count Spalten) stimmt nicht mit den Spalten der Kopfzeile \':header_data\' (:header_count Spalten) überein.',
     'name-column-does-not-exist' => 'Die Spalte für den Namen existiert nicht: :column',
     'parent-column-does-non-exist' => 'Die Spalte für die Eltern-Entität existiert nicht: :column',
     'parent-entity-does-not-exist' => 'Die Eltern-Entität existiert nicht: :entity',

--- a/lang/en/entity-importer.php
+++ b/lang/en/entity-importer.php
@@ -5,6 +5,7 @@ return [
     'file-not-found' => 'File could not be read.',
     'missing-data' => 'Required column is missing: :column',
     'invalid-data' => 'Invalid data: [:column] => :value',
+    'csv-column-mismatch' => 'Column count of current row \':data\' (:data_count columns) does not match column count in header row \':header_data\' (:header_count columns).',
     'attribute-could-not-be-imported' => 'Attribute could not be imported: :attribute',
     'attribute-id-does-not-exist' => 'The attribute id does not exist: :attributes',
     'attribute-column-does-not-exist' => 'The attribute columns do not exist: :columns',

--- a/tests/Feature/ApiDataImporterTest.php
+++ b/tests/Feature/ApiDataImporterTest.php
@@ -14,22 +14,32 @@ class ApiDataImporterTest extends TestCase {
      * Utilities
      * 
      */
-    private function createDefaultCSVFile($delimiter = ",") {
-        return $this->createCSVFile([
-            ['name', 'parent', 'Notizen', 'Alternativer Name'],
+    private function createDefaultCSVFile($delimiter = ",", $hasHeaderRow = true) {
+        $columns = [
             ['Yamato', 'Site A\\\\Befund 1\\\\Inv. 1234', 'yellow', 'lee;steve;dave'],
             ['大和', '', '黃色的', '王;伟祺;平安'],
             ['やまと', 'Site A', 'きいろい', "ひまり;まゆみ;ユイ"],
             ['ياماتو', 'Site B', 'أصفر', "عَلِي;يُوْسِف;حَسَن"],
             ['Site A', '', 'Updated', 'Alternative Site']
-        ], $delimiter);
+        ];
+        
+        if($hasHeaderRow) {
+            array_unshift($columns, ['name', 'parent', 'Notizen', 'Alternativer Name']);
+        }
+        
+        return $this->createCSVFile($columns, $delimiter);
     }
 
-    private function createDimensionsCSVFile($delimiter = ",") {
-        return $this->createCSVFile([
-            ['name', 'parent', 'Abmessungen'],
+    private function createDimensionsCSVFile($delimiter = ",", $hasHeaderRow = true) {
+        $columns = [
             ['imported', 'Site A', '1;2;3;cm'],
-        ], $delimiter);
+        ];
+        
+        if($hasHeaderRow) {
+            array_unshift($columns, ['name', 'parent', 'Abmessungen']);
+        }
+        
+        return $this->createCSVFile($columns, $delimiter);
     }
 
     private function createCSVFile(array $tableData, $delimiter = ",") {
@@ -45,7 +55,8 @@ class ApiDataImporterTest extends TestCase {
 
         return UploadedFile::fake()->createWithContent('data.csv', $content);
     }
-
+    
+    
     private function getData(?string $name = 'name', int $entityTypeId = 3, array $attributes = [], ?string $parentColumn = null) {
         return json_encode([
             "name_column" => $name,
@@ -54,7 +65,7 @@ class ApiDataImporterTest extends TestCase {
             "attributes" => $attributes,
         ]);
     }
-
+    
     private function getDimensionsData() {
         return $this->getData(
             parentColumn: 'parent',
@@ -74,12 +85,16 @@ class ApiDataImporterTest extends TestCase {
     }
 
     /**
+     * We run the tests two times. Once with a header row and once without.
+     */
+   
+    /**
      * 
-     * Tests
+     * TESTS WITH NAMED HEADERS
      * 
      */
-
-    public function testValidationEmptyFile() {
+   
+     public function testValidationEmptyFile() {
         $file = $this->createCSVFile([]);
         $metadata = $this->getMetaData();
 
@@ -576,5 +591,409 @@ class ApiDataImporterTest extends TestCase {
                 'on_name' => null
             ]
         ]);
+    }
+    
+    /**
+    * 
+    * TESTS WITH NO HEADERS
+    * 
+    */
+   
+    public function testValidationEmptyFileNoHeaders() {
+        $file = $this->createCSVFile([]);
+        $metadata = $this->getMetaData(hasHeaderRow: false);
+
+        $this->userRequest()->post('/api/v1/entity/import/validate', [
+            'file' => $file,
+            'data' => $this->getData(),
+            'metadata' => $metadata,
+        ])
+            ->assertStatus(200)
+            ->assertJson([
+                "errors" => [
+                    "No rows to import"
+                ],
+                "summary" => [
+                    "create" => 0,
+                    "update" => 0,
+                    "conflict" => 1
+                ]
+            ]);
+    }
+
+    public function testValidationNamesColumnMissingErrorNoHeaders() {
+        $file = $this->createCSVFile([['other'], [''], ['other 2']]);
+        $metadata = $this->getMetaData(hasHeaderRow: false);
+
+        $response = $this->userRequest()->post('/api/v1/entity/import/validate', [
+            'file' => $file,
+            'data' => $this->getData(name: '#4'),
+            'metadata' => $metadata,
+        ])->assertStatus(200);
+
+        $response->assertJson([
+            "errors" => [
+                "The column for the name does not exist: #4"
+            ],
+            "summary" => [
+                "create" => 0,
+                "update" => 0,
+                "conflict" => 1
+            ]
+        ]);
+    }
+
+    public function testValidationNamesColumnNullErrorNoHeaders() {
+        $file = $this->createCSVFile([['other'], [''], ['other 2']]);
+        $metadata = $this->getMetaData(hasHeaderRow: false);
+
+        $response = $this->userRequest()->post('/api/v1/entity/import/validate', [
+            'file' => $file,
+            'data' => $this->getData(name: null),
+            'metadata' => $metadata,
+        ])->assertStatus(200);
+
+        $response->assertJson([
+            "errors" => [
+                "Required column is missing: name_column"
+            ],
+            "summary" => [
+                "create" => 0,
+                "update" => 0,
+                "conflict" => 1
+            ]
+        ]);
+    }
+
+    public function testValidationWithAllNamesSetCorrectlyNoHeaders() {
+        $metadata = $this->getMetaData(hasHeaderRow: false);
+
+        $this->userRequest()->post('/api/v1/entity/import/validate', [
+            'file' => $this->createDefaultCSVFile(hasHeaderRow: false),
+            'data' => $this->getData(name: '#1'),
+            'metadata' => $metadata,
+        ])
+            ->assertStatus(200)
+            ->assertJson([
+                "errors" => [],
+                "summary" => [
+                    "create" => 4,
+                    "update" => 1,
+                    "conflict" => 0
+                ]
+            ]);
+    }
+
+    public function testValidationWithInvalidTypeIdNoHeaders() {
+        $metadata = $this->getMetaData(hasHeaderRow: false);
+
+        $response = $this->userRequest()->post('/api/v1/entity/import/validate', [
+            'file' => $this->createDefaultCSVFile(hasHeaderRow: false),
+            'data' => $this->getData(name: "#1", entityTypeId: -1),
+            'metadata' => $metadata,
+        ])->assertStatus(200);
+
+        $response->assertJson([
+            'errors' => ['The entity type does not exist: -1'],
+            "summary" => [
+                "create" => 0,
+                "update" => 0,
+                "conflict" => 1
+            ]
+        ]);
+    }
+
+    public function testValidationInvalidFileNoHeaders() {
+        $metadata = $this->getMetaData(hasHeaderRow: false);
+
+        $this->userRequest()->post('/api/v1/entity/import/validate', [
+            'file' => null,
+            'data' => $this->getData(name: "#1"),
+            'metadata' => $metadata,
+        ])
+            ->assertStatus(422)
+            ->assertJson([
+                "message" => "The file field is required.",
+                "errors" => [
+                    "file" => [
+                        "The file field is required."
+                    ]
+                ]
+            ]);
+    }
+
+    public function testValidationIncorrectDelimiterNoHeaders() {
+        $metadata = $this->getMetaData(delimiter: ',', hasHeaderRow: false);
+
+        $this->userRequest()->post('/api/v1/entity/import/validate', [
+            'file' => $this->createDefaultCSVFile(hasHeaderRow: false, delimiter:';'),
+            'data' => $this->getData(),
+            'metadata' => $metadata,
+        ])
+            ->assertStatus(200)
+            ->assertJson([
+                "errors" => ["The column for the name does not exist: name"],
+                "summary" => [
+                    "create" => 0,
+                    "update" => 0,
+                    "conflict" => 1
+                ]
+            ]);
+    }
+
+    public function testValidationCorrectDelimiterNoHeaders() {
+        $metadata = $this->getMetaData(delimiter: ';', hasHeaderRow: false);
+
+        $this->userRequest()->post('/api/v1/entity/import/validate', [
+            'file' => $this->createDefaultCSVFile(hasHeaderRow: false, delimiter:';'),
+            'data' => $this->getData(name: "#1"),
+            'metadata' => $metadata,
+        ])
+            ->assertStatus(200)
+            ->assertJson([
+                "errors" => [],
+                "summary" => [
+                    "create" => 4,
+                    "update" => 1,
+                    "conflict" => 0
+                ]
+            ]);
+    }
+
+    public function testValidationWithParentColumnNoHeaders() {
+        $metadata = $this->getMetaData(hasHeaderRow: false);
+
+        $this->userRequest()->post('/api/v1/entity/import/validate', [
+            'file' => $this->createDefaultCSVFile(hasHeaderRow: false),
+            'data' => $this->getData(name: "#1", parentColumn: '#2'),
+            'metadata' => $metadata,
+        ])
+            ->assertStatus(200)
+            ->assertJson([
+                "errors" => [],
+                "summary" => [
+                    "create" => 4,
+                    "update" => 1,
+                    "conflict" => 0
+                ]
+            ]);
+    }
+
+    public function testValidationWithParentColumnChildTypeNotAllowedNoHeaders() {
+        $file = $this->createCSVFile([
+            ['parent not allowed', 'Site A\\\\Befund 1\\\\Inv. 31', '6 is parent of 3']
+        ]);
+        $metadata = $this->getMetaData(hasHeaderRow: false);
+
+        $this->userRequest()->post('/api/v1/entity/import/validate', [
+            'file' => $file,
+            'data' => $this->getData(name: "#1", parentColumn: '#2'),
+            'metadata' => $metadata,
+        ])
+            ->assertStatus(200)
+            ->assertJson([
+                'errors' => ['[1] The relationship between entity types is not allowed: Stone -> Site'],
+                "summary" => [
+                    "create" => 0,
+                    "update" => 0,
+                    "conflict" => 1
+                ]
+            ]);
+    }
+
+    public function testValidationWithParentColumnTopLevelElementAlreadyExistsNoHeaders() {
+        $file = $this->createCSVFile([
+            ['Site A', '', '']
+        ]);
+        $metadata = $this->getMetaData(hasHeaderRow: false);
+
+        $this->userRequest()->post('/api/v1/entity/import/validate', [
+            'file' => $file,
+            'data' => $this->getData(name: "#1", parentColumn: '#2'),
+            'metadata' => $metadata,
+        ])
+            ->assertStatus(200)
+            ->assertJson([
+                'errors' => [],
+                "summary" => [
+                    "create" => 0,
+                    "update" => 1,
+                    "conflict" => 0
+                ]
+            ]);
+    }
+
+    public function testValidationWithParentColumnSubElementAlreadyExistsNoHeaders() {
+        $file = $this->createCSVFile([
+            ['Fund 12', 'Site B', 'Fund 12 does already exist at this location.']
+        ]);
+        $metadata = $this->getMetaData(hasHeaderRow: false);
+
+        $this->userRequest()->post('/api/v1/entity/import/validate', [
+            'file' => $file,
+            'data' => $this->getData(name: "#1", parentColumn: '#2'),
+            'metadata' => $metadata,
+        ])
+            ->assertStatus(200)
+            ->assertJson([
+                'errors' => [],
+                "summary" => [
+                    "create" => 0,
+                    "update" => 1,
+                    "conflict" => 0
+                ]
+            ]);
+    }
+
+    public function testValidationOfAttributesNoHeaders() {
+        $metadata = $this->getMetaData(hasHeaderRow: false);
+
+        $this->userRequest()->post('/api/v1/entity/import/validate', [
+            'file' => $this->createDefaultCSVFile(hasHeaderRow: false),
+            'data' => $this->getData(
+                name: "#1",     
+                attributes: [
+                8 => "#3",
+                15 => "#4"
+            ]),
+            'metadata' => $metadata,
+        ])
+            ->assertStatus(200)
+            ->assertJson([
+                'errors' => [],
+                "summary" => [
+                    "create" => 4,
+                    "update" => 1,
+                    "conflict" => 0
+                ]
+            ]);
+    }
+
+    public function testValidationOfAttributesInvalidColumnNameNoHeaders() {
+        $metadata = $this->getMetaData(hasHeaderRow: false);
+
+        $this->userRequest()->post('/api/v1/entity/import/validate', [
+            'file' => $this->createDefaultCSVFile(hasHeaderRow: false),
+            'data' => $this->getData(
+                name: "#1", 
+                attributes: [
+                8 => "#10",
+                15 => "#11"
+            ]),
+            'metadata' => $metadata,
+        ])->assertJson([
+            'errors' => ["The attribute columns do not exist: #10, #11"],
+            "summary" => [
+                "create" => 0,
+                "update" => 0,
+                "conflict" => 1
+            ]
+        ]);
+    }
+
+    public function testValidationOfAttributesInvalidAttributeIdNoHeaders() {
+        $metadata = $this->getMetaData(hasHeaderRow: false);
+
+        $this->userRequest()->post('/api/v1/entity/import/validate', [
+            'file' => $this->createDefaultCSVFile(hasHeaderRow: false),
+            'data' => $this->getData(
+                name: "#1",
+                attributes: [
+                -1 => "#3",
+                -1 => "#4"
+            ]),
+            'metadata' => $metadata,
+        ])
+            ->assertStatus(200)
+            ->assertJson([
+                'errors' => ['The attribute id does not exist: -1'],
+                "summary" => [
+                    "create" => 0,
+                    "update" => 0,
+                    "conflict" => 1
+                ]
+            ]);
+    }
+
+    public function testValidationOfAttributesInvalidAttributeIdAndInvalidColumnNameNoHeaders() {
+        $metadata = $this->getMetaData(hasHeaderRow: false);
+
+        $this->userRequest()->post('/api/v1/entity/import/validate', [
+            'file' => $this->createDefaultCSVFile(hasHeaderRow: false),
+            'data' => $this->getData(
+                name: "#1", 
+                attributes: [
+                -1 => "#11",
+            ]),
+            'metadata' => $metadata,
+        ])
+            ->assertStatus(200)
+            ->assertJson([
+                'errors' => [
+                    'The attribute id does not exist: -1',
+                    'The attribute columns do not exist: #11',
+                ],
+                'summary' => [
+                    'create' => 0,
+                    'update' => 0,
+                    'conflict' => 2
+                ]
+            ]);
+    }
+
+    public function testValidationOfAttributeValueSucceedsNoHeaders() {
+        $metadata = $this->getMetaData(hasHeaderRow: false);
+
+        $this->userRequest()->post('/api/v1/entity/import/validate', [
+            'file' => $this->createCSVFile([
+                ['good', 'Site A', '1;2;3;cm'],
+            ]),
+            'data' => $this->getData(
+                name: "#1",
+                parentColumn: '#2',
+                entityTypeId: 6,
+                attributes: [
+                    9 => "#3",
+                ]
+            ),
+            'metadata' => $metadata,
+        ])
+            ->assertStatus(200)
+            ->assertJson([
+                'errors' => [],
+                'summary' => [
+                    'create' => 1,
+                    'update' => 0,
+                    'conflict' => 0
+                ]
+            ]);
+    }
+
+    public function testValidationOfAttributeValueFailsNoHeaders() {
+        $metadata = $this->getMetaData(hasHeaderRow: false);
+
+        $this->userRequest()->post('/api/v1/entity/import/validate', [
+            'file' => $this->createCSVFile([
+                ['bad',  'Site A', '1,2,3,cm'],
+            ]),
+            'data' => $this->getData(
+                name: "#1",
+                parentColumn: '#2',
+                entityTypeId: 6,
+                attributes: [
+                    9 => "#3",
+                ]
+            ),
+            'metadata' => $metadata,
+        ])
+            ->assertStatus(200)
+            ->assertJson([
+                'errors' => ['[1] Attribute could not be imported: #3'],
+                'summary' => [
+                    'create' => 1,
+                    'update' => 0,
+                    'conflict' => 1,
+                ]
+            ]);
     }
 }


### PR DESCRIPTION
I tried to import a CSV without a header. And noticed that it fails.
This pull request fixes that and adds all tests for the 'NoHeaders' variant.