### PR TITLE
[0.11] fix sql attribute without entity

### DIFF
--- a/app/AttributeTypes/SqlAttribute.php
+++ b/app/AttributeTypes/SqlAttribute.php
@@ -2,6 +2,8 @@
 
 namespace App\AttributeTypes;
 
+use Illuminate\Support\Facades\DB;
+
 class SqlAttribute extends StaticAttribute
 {
     protected static string $type = "sql";
@@ -14,5 +16,37 @@ class SqlAttribute extends StaticAttribute
 
     public static function serialize(mixed $data) : mixed {
         return false;
+    }
+    
+    
+    public static function execute($sql, $entityId) {
+        // if entity_id is referenced several times
+        // add an incrementing counter, so the
+        // references are unique (required by PDO)
+        $i = 0;
+        $safes = [];
+        $text = preg_replace_callback('/:entity_id/', function ($matches) use (&$i, &$safes) {
+            ++$i;
+            $safes[':entity_id_' . $i] = $entityId;
+            return $matches[0] . '_' . $i;
+        }, $sql);
+        
+        DB::beginTransaction();
+        $sqlValue = DB::select($text, $safes);
+        DB::rollBack();
+
+        // Check if only one result exists
+        if(count($sqlValue) === 1) {
+            // Get all column indices (keys) using the first row
+            $valueKeys = array_keys(get_object_vars($sqlValue[0]));
+            // Check if also only one key/column exists
+            if(count($valueKeys) === 1) {
+                // If only one row and one column exist,
+                // return plain value instead of array
+                $firstKey = $valueKeys[0];
+                $sqlValue = $sqlValue[0]->{$firstKey};
+            }
+        }
+        return $sqlValue;
     }
 }

--- a/app/AttributeTypes/SqlAttribute.php
+++ b/app/AttributeTypes/SqlAttribute.php
@@ -17,20 +17,19 @@ class SqlAttribute extends StaticAttribute
     public static function serialize(mixed $data) : mixed {
         return false;
     }
-    
-    
-    public static function execute($sql, $entityId) {
+
+    public static function execute(string $sql, int $entityId) : array|string {
         // if entity_id is referenced several times
         // add an incrementing counter, so the
         // references are unique (required by PDO)
         $i = 0;
         $safes = [];
-        $text = preg_replace_callback('/:entity_id/', function ($matches) use (&$i, &$safes) {
+        $text = preg_replace_callback('/:entity_id/', function($matches) use (&$i, &$safes, $entityId) {
             ++$i;
             $safes[':entity_id_' . $i] = $entityId;
             return $matches[0] . '_' . $i;
         }, $sql);
-        
+
         DB::beginTransaction();
         $sqlValue = DB::select($text, $safes);
         DB::rollBack();

--- a/routes/api.php
+++ b/routes/api.php
@@ -45,6 +45,8 @@ Route::middleware(['before' => 'jwt.auth', 'after' => 'jwt.refresh'])->prefix('v
 Route::middleware(['before' => 'jwt.auth', 'after' => 'jwt.refresh'])->prefix('v1/entity')->group(function() {
     Route::get('/top', 'EntityController@getTopEntities');
     Route::get('/{id}', 'EntityController@getEntity')->where('id', '[0-9]+');
+    
+    // This route is only used for the map plugin 
     Route::get('/entity_type/{etid}/data/{aid}', 'EntityController@getDataForEntityType')->where('etid', '[0-9]+')->where('aid', '[0-9]+');
     Route::get('/{id}/data', 'EntityController@getData')->where('id', '[0-9]+');
     Route::get('/{id}/data/{aid}', 'EntityController@getData')->where('id', '[0-9]+')->where('aid', '[0-9]+');


### PR DESCRIPTION
When using the sql attribute without specifying the *:entity_id* parameter, then an error was thrown. 
This PR allows queries to not have this attribute and the funcitonality was moved to the SqlAttribute.php to make the Controller cleaner. 