### PR TITLE
[0.11] fix deprecated php strings

### DIFF
--- a/app/Plugin.php
+++ b/app/Plugin.php
@@ -41,7 +41,7 @@ class Plugin extends Model
     public function publicName($withPath = true) {
         $slug = $this->slugName();
         $uuid = $this->uuid;
-        $name = "${slug}-${uuid}.js";
+        $name = "{$slug}-{$uuid}.js";
         if($withPath) {
             $name = "plugins/$name";
         }

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -52,7 +52,7 @@ if(!function_exists('sp_get_permission_groups')) {
 if(!function_exists('sp_get_themes')) {
     function sp_get_themes() {
         $themeDir = base_path("resources/sass/");
-        $fileList = glob("${themeDir}app*.scss");
+        $fileList = glob("{$themeDir}app*.scss");
         $themes = [];
         foreach($fileList as $file) {
             $theme = [];


### PR DESCRIPTION
As of PHP 8.2 the string format ${var} is deprecated and can be replaced with {$var}.

https://php.watch/versions/8.2/$%7Bvar%7D-string-interpolation-deprecated