### PR TITLE
[0.11] Speed up tree loading

### DIFF
--- a/app/Http/Controllers/EntityController.php
+++ b/app/Http/Controllers/EntityController.php
@@ -47,7 +47,7 @@ class EntityController extends Controller {
                 'error' => __('You do not have the permission to get entities'),
             ], 403);
         }
-        $roots = Entity::getEntitiesByParent(null);
+        $roots = Entity::getEntitiesByParent(null, true);
 
         return response()->json($roots);
     }
@@ -249,6 +249,29 @@ class EntityController extends Controller {
         return response()->json($entity->parentIds);
     }
 
+    // TODO merge with getParentIds($id) method
+    public function getParentMetadata($id) {
+        $user = auth()->user();
+        if(!$user->can('entity_read')) {
+            return response()->json([
+                'error' => __('You do not have the permission to get an entity\'s parent id\'s'),
+            ], 403);
+        }
+
+        try {
+            $entity = Entity::findOrFail($id);
+        } catch(ModelNotFoundException $e) {
+            return response()->json([
+                'error' => __('This entity does not exist'),
+            ], 400);
+        }
+        return response()->json([
+            'parentIds' => $entity->parentIds,
+            'parentNames' => $entity->parentNames,
+            'attributeLinks' => $entity->attributeLinks,
+        ]);
+    }
+
     public function getEntitiesByParent($id) {
         $user = auth()->user();
         if(!$user->can('entity_read')) {
@@ -257,7 +280,7 @@ class EntityController extends Controller {
             ], 403);
         }
 
-        return Entity::getEntitiesByParent($id);
+        return Entity::getEntitiesByParent($id, true);
     }
 
     // POST

--- a/resources/js/api.js
+++ b/resources/js/api.js
@@ -154,6 +154,16 @@ export async function getEntityParentIds(id) {
     );
 }
 
+// TODO merge with getEntityParentIds(id) method
+export async function getEntityParentMetadata(id) {
+    return await $httpQueue.add(
+        () => http.get(`/entity/${id}/parentMetadata`)
+            .then(response => {
+                return response.data;
+            })
+    );
+}
+
 export async function getEntityData(id) {
     return await $httpQueue.add(
         () => http.get(`/entity/${id}/data`)

--- a/resources/js/bootstrap/stores/entity.js
+++ b/resources/js/bootstrap/stores/entity.js
@@ -35,6 +35,7 @@ import {
     getEntityComments,
     getEntityData,
     getEntityParentIds,
+    getEntityParentMetadata,
     getEntityReferences,
     handleModeration,
     moveEntity,
@@ -612,6 +613,12 @@ export const useEntityStore = defineStore('entity', {
                 const ids = await getEntityParentIds(entityId);
                 await openPath(ids);
                 entity = this.entities[entityId];
+            }
+            if(!entity.parentIds) {
+                const parentMetadata = await getEntityParentMetadata(entityId);
+                this.entities[entityId].parentIds = parentMetadata.parentIds;
+                this.entities[entityId].parentNames = parentMetadata.parentNames;
+                this.entities[entityId].attributeLinks = parentMetadata.attributeLinks;
             }
             if(!can('entity_data_read')) {
                 entity = {

--- a/resources/js/components/tree/Entity.vue
+++ b/resources/js/components/tree/Entity.vue
@@ -284,12 +284,31 @@
                 }
                 return newRank;
             };
+            const checkIsPartOfPath = (path, part) => {
+                if(path.length == 0 || part.length == 0) {
+                    return false;
+                }
+                if(part.length > path.length) {
+                    return false;
+                }
+
+                for(let i=0; i<part.length; i++) {
+                    if(part[i] != path[i]) {
+                        return false;
+                    }
+                }
+
+                return true;
+            };
             const isDropAllowed = dropData => {
                 const item = dropData.sourceData;
                 const target = dropData.targetData;
                 const dragEntityType = entityStore.getEntityType(item.entity_type_id);
 
-                if(target.parentIds.indexOf(item.id) != -1 ||
+                const targetParentPath = dropData.targetPath.slice(0, -1);
+                const sourceParentPath = dropData.sourcePath;
+                const sourceIsParent = checkIsPartOfPath(targetParentPath, sourceParentPath);
+                if(sourceIsParent ||
                     (target.state.dropPosition == DropPosition.inside && target.id == item.root_entity_id)) {
                     return false;
                 }

--- a/routes/api.php
+++ b/routes/api.php
@@ -54,6 +54,8 @@ Route::middleware('auth:sanctum')->prefix('v1/entity')->group(function() {
     Route::get('/{id}/reference', 'ReferenceController@getByEntity')->where('id', '[0-9]+');
     Route::get('/{id}/export', 'EntityController@exportEntityTree')->where('id', '[0-9]+');
     Route::get('/{id}/parentIds', 'EntityController@getParentIds')->where('id', '[0-9]+');
+    // TODO merge with /{id}/parentIds route
+    Route::get('/{id}/parentMetadata', 'EntityController@getParentMetadata')->where('id', '[0-9]+');
     Route::get('/byParent/{id}', 'EntityController@getEntitiesByParent')->where('id', '[0-9]+');
 
     Route::post('', 'EntityController@addEntity');


### PR DESCRIPTION
The API call to load the initial entity tree or a sub-tree could take a long time, because additional data was loaded. But this data is only needed when an entity is selected. So I removed that data from the original API call and load it on demand.
The drag&drop logic also relied on that data, but could also use the available path data.